### PR TITLE
Authentication

### DIFF
--- a/api/.gitignore
+++ b/api/.gitignore
@@ -1,2 +1,3 @@
 /node_modules
 /.env
+/lastSessionId

--- a/api/scripts/clearDb.js
+++ b/api/scripts/clearDb.js
@@ -6,6 +6,8 @@ const sequelize = createSequelize()
 sequelize.authenticate()
 	.then(() => new Database(sequelize))
 	.then(async () => {
+		await sequelize.query('DROP SCHEMA public CASCADE;')
+		await sequelize.query('CREATE SCHEMA public;')
 		await sequelize.sync({ force: true })
 	})
 	.catch(console.error)

--- a/api/scripts/startWebserver.js
+++ b/api/scripts/startWebserver.js
@@ -29,6 +29,11 @@ sequelize.authenticate()
 			sessionStore,
 			surfConextClient,
 		})
+
+		if (process.env.NODE_ENV === 'development') {
+			server.get(SurfConextMock.DIRECTORY_PATH, SurfConextMock.userDirectory)
+		}
+
 		server.listen(process.env.PORT, () => {
 			console.log(`Server listening on port ${process.env.PORT}`)
 		})

--- a/api/src/database/models/SurfConextProfile.js
+++ b/api/src/database/models/SurfConextProfile.js
@@ -1,10 +1,13 @@
 module.exports = (sequelize, DataTypes) => {
 	const SurfConextProfile = sequelize.define('surfConextProfile', {
 		sub: {
-			type: DataTypes.STRING,
+			type: DataTypes.UUID,
 			allowNull: false,
-			unique: true,
+			primaryKey: true,
 		},
+		schacHomeOrganization: {
+			type: DataTypes.STRING,
+		}
 	})
 
 	SurfConextProfile.associate = models => {

--- a/api/src/graphql/schemas/User.js
+++ b/api/src/graphql/schemas/User.js
@@ -6,6 +6,7 @@ const schema = gql`
   }
 
 	type User {
+		id: ID!
 		name: String!
 		email: EmailAddress!
 		skills(ids: [String]): [SkillWithoutExercises]!

--- a/api/src/server/authHandler.js
+++ b/api/src/server/authHandler.js
@@ -40,17 +40,6 @@ class AuthStrategyTemplate {
 	 * @returns User|null			User object from database
 	 * @throws
 	 */
-	async findUser(authData) {
-		return null
-	}
-
-	/**
-	 * Tries to find a user in our system or creates it otherwise
-	 *
-	 * @param authData				Provider-specific user data
-	 * @returns User|null			User object from database
-	 * @throws
-	 */
 	async findOrCreateUser(authData) {
 		throw AuthStrategyInterface.UNKNOWN_ERROR
 	}
@@ -64,10 +53,10 @@ class AuthStrategyTemplate {
 const createAuthHandler = (homepageUrl, authStrategy) => {
 	const router = express.Router()
 
-	const handler = retrieveUser => async (req, res) => {
+	router.get('/login', async (req, res) => {
 		try {
 			const authData = await authStrategy.authenticate(req)
-			const user = await retrieveUser(authData)
+			const user = await authStrategy.findOrCreateUser(authData)
 			req.session.principal = {
 				id: user.id
 			}
@@ -81,10 +70,8 @@ const createAuthHandler = (homepageUrl, authStrategy) => {
 			}
 			res.redirect(`${homepageUrl}?error=${code}`)
 		}
-	}
+	})
 
-	router.get('/register', handler(authData => authStrategy.findOrCreateUser(authData)))
-	router.get('/login', handler(authData => authStrategy.findUser(authData)))
 	router.get('/initiate', async (req, res) => {
 		try {
 			req.session.initiated = new Date()

--- a/api/src/server/surfConext/devmock.js
+++ b/api/src/server/surfConext/devmock.js
@@ -35,6 +35,19 @@ const createPrefilledMemoryStore = () => {
 	return memoryStore
 }
 
+const userDirectory = (req, res) => {
+	const list = USERINFO.map(u => `<li>
+			<a href="/auth/surfconext/login?sub=${u.sub}">
+				${u.name} &lt;${u.email}&gt;
+			</a>
+		</li>
+	`)
+	res.send(`<!doctype html>
+		<html><body>
+			<h1>SurfConext Mock Users</h1>
+			<ul>${list.join('')}`)
+}
+
 module.exports = {
-	MockClient, createPrefilledMemoryStore
+	MockClient, createPrefilledMemoryStore, userDirectory, DIRECTORY_PATH
 }


### PR DESCRIPTION
- The session-id persistence is handled a bit differently now locally, because the old implementation was quite hacky. What we are doing now is storing the latest session-id in a file and recovering that on server restart. It will always recover to the “special user” though, that’s the only flaw. But otherwise this technique should be more robust.
- Since we are using the regular SurfConext authentication flow locally (except that the real SurfConext API is mocked), you can log in with other users as well. Click on the “Login” button to try it out, then you see how it works. The list of mock users will of course only be shown locally.
- Unknown users are implicitly registered now, as discussed yesterday. The properties of known users are updated on every login. Once we add more properties to the user this must be extended (see `server/surfConext/authStrategy.js`).

Don’t forget to run `npm run db:clear` and seed once again, due to DB schema changes.