### PR TITLE
Introduce database migrations

### DIFF
--- a/api/migrations/000_create-table-users.js
+++ b/api/migrations/000_create-table-users.js
@@ -1,0 +1,35 @@
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+	up: async (sequelize) => {
+		await sequelize.createTable('users', {
+			id: {
+				type: DataTypes.UUID,
+				defaultValue: DataTypes.UUIDV4,
+				allowNull: false,
+				primaryKey: true,
+			},
+			name: {
+				type: DataTypes.STRING,
+				allowNull: false,
+			},
+			email: {
+				type: DataTypes.STRING,
+				allowNull: false,
+			},
+			createdAt: {
+				type: DataTypes.DATE,
+				allowNull: false,
+			},
+			updatedAt: {
+				type: DataTypes.DATE,
+				allowNull: false,
+			},
+		})
+	},
+
+	down: async (sequelize) => {
+		sequelize.dropTable('users')
+	},
+
+}

--- a/api/migrations/001_create-table-userSkills.js
+++ b/api/migrations/001_create-table-userSkills.js
@@ -1,0 +1,70 @@
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+	up: async (sequelize) => {
+		await sequelize.createTable('userSkills', {
+			id: {
+				type: DataTypes.UUID,
+				defaultValue: DataTypes.UUIDV4,
+				allowNull: false,
+				primaryKey: true,
+			},
+			userId: {
+				type: DataTypes.UUID,
+				references: {
+					model: 'users',
+					key: 'id',
+				},
+				onUpdate: 'cascade',
+				onDelete: 'cascade',
+			},
+			skillId: {
+				type: DataTypes.STRING,
+				allowNull: false,
+			},
+			numPracticed: {
+				type: DataTypes.INTEGER,
+				defaultValue: 0,
+				allowNull: false,
+			},
+			coefficients: {
+				type: DataTypes.ARRAY(DataTypes.DOUBLE),
+				defaultValue: [1],
+				allowNull: false,
+			},
+			coefficientsOn: {
+				type: DataTypes.DATE,
+				defaultValue: DataTypes.NOW,
+				allowNull: false,
+			},
+			highest: {
+				type: DataTypes.ARRAY(DataTypes.DOUBLE),
+				defaultValue: [1],
+				allowNull: false,
+			},
+			highestOn: {
+				type: DataTypes.DATE,
+				defaultValue: DataTypes.NOW,
+				allowNull: false,
+			},
+			createdAt: {
+				type: DataTypes.DATE,
+				allowNull: false,
+			},
+			updatedAt: {
+				type: DataTypes.DATE,
+				allowNull: false,
+			},
+		})
+		await sequelize.addIndex('userSkills', {
+			fields: ['userId', 'skillId'],
+			unique: true,
+		})
+
+	},
+
+	down: async (sequelize) => {
+		sequelize.dropTable('userSkills')
+	},
+
+}

--- a/api/migrations/002_create-table-surfConextProfiles.js
+++ b/api/migrations/002_create-table-surfConextProfiles.js
@@ -1,0 +1,38 @@
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+	up: async (sequelize) => {
+		await sequelize.createTable('surfConextProfiles', {
+			id: {
+				type: DataTypes.STRING,
+				allowNull: false,
+				primaryKey: true,
+			},
+			userId: {
+				type: DataTypes.UUID,
+				references: {
+					model: 'users',
+					key: 'id',
+				},
+				onUpdate: 'cascade',
+				onDelete: 'cascade',
+			},
+			schacHomeOrganization: {
+				type: DataTypes.STRING,
+			},
+			createdAt: {
+				type: DataTypes.DATE,
+				allowNull: false,
+			},
+			updatedAt: {
+				type: DataTypes.DATE,
+				allowNull: false,
+			},
+		})
+	},
+
+	down: async (sequelize) => {
+		sequelize.dropTable('surfConextProfiles')
+	},
+
+}

--- a/api/migrations/003_create-table-exerciseSamples.js
+++ b/api/migrations/003_create-table-exerciseSamples.js
@@ -1,0 +1,49 @@
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+	up: async (sequelize) => {
+		await sequelize.createTable('exerciseSamples', {
+			id: {
+				type: DataTypes.UUID,
+				defaultValue: DataTypes.UUIDV4,
+				allowNull: false,
+				primaryKey: true,
+			},
+			userSkillId: {
+				type: DataTypes.UUID,
+				references: {
+					model: 'userSkills',
+					key: 'id',
+				},
+				onUpdate: 'cascade',
+				onDelete: 'cascade',
+			},
+			exerciseId: {
+				type: DataTypes.STRING,
+				allowNull: false,
+			},
+			state: {
+				type: DataTypes.JSON,
+				allowNull: false,
+			},
+			active: {
+				type: DataTypes.BOOLEAN,
+				defaultValue: true,
+				allowNull: false,
+			},
+			createdAt: {
+				type: DataTypes.DATE,
+				allowNull: false,
+			},
+			updatedAt: {
+				type: DataTypes.DATE,
+				allowNull: false,
+			},
+		})
+	},
+
+	down: async (sequelize) => {
+		sequelize.dropTable('exerciseSamples')
+	},
+
+}

--- a/api/migrations/004_create-table-exerciseEvents.js
+++ b/api/migrations/004_create-table-exerciseEvents.js
@@ -1,0 +1,44 @@
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+	up: async (sequelize) => {
+		await sequelize.createTable('exerciseEvents', {
+			id: {
+				type: DataTypes.UUID,
+				defaultValue: DataTypes.UUIDV4,
+				allowNull: false,
+				primaryKey: true,
+			},
+			action: {
+				type: DataTypes.JSON,
+				allowNull: false,
+			},
+			progress: {
+				type: DataTypes.JSON,
+				allowNull: false,
+			},
+			exerciseSampleId: {
+				type: DataTypes.UUID,
+				references: {
+					model: 'exerciseSamples',
+					key: 'id',
+				},
+				onUpdate: 'cascade',
+				onDelete: 'cascade',
+			},
+			createdAt: {
+				type: DataTypes.DATE,
+				allowNull: false,
+			},
+			updatedAt: {
+				type: DataTypes.DATE,
+				allowNull: false,
+			},
+		})
+	},
+
+	down: async (sequelize) => {
+		sequelize.dropTable('exerciseEvents')
+	},
+
+}

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1743,6 +1743,11 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
+    "bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -6748,6 +6753,14 @@
       "integrity": "sha512-KPHm4VL5dDXKz01UuEd88Df+KzynaohSL9fBh096KWAxSKZQDI2uBrVqtvRM4rwrIrRRKsdLNML/lnaaVSRioA==",
       "requires": {
         "random-bytes": "~1.0.0"
+      }
+    },
+    "umzug": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/umzug/-/umzug-2.3.0.tgz",
+      "integrity": "sha512-Z274K+e8goZK8QJxmbRPhl89HPO1K+ORFtm6rySPhFKfKc5GHhqdzD0SGhSWHkzoXasqJuItdhorSvY7/Cgflw==",
+      "requires": {
+        "bluebird": "^3.7.2"
       }
     },
     "undefsafe": {

--- a/api/package-lock.json
+++ b/api/package-lock.json
@@ -1743,11 +1743,6 @@
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
       "dev": true
     },
-    "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
-    },
     "body-parser": {
       "version": "1.19.0",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.19.0.tgz",
@@ -2013,15 +2008,6 @@
       "integrity": "sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=",
       "requires": {
         "mimic-response": "^1.0.0"
-      }
-    },
-    "cls-bluebird": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/cls-bluebird/-/cls-bluebird-2.1.0.tgz",
-      "integrity": "sha1-N+8eCAqP+1XC9BZPU28ZGeeWiu4=",
-      "requires": {
-        "is-bluebird": "^1.0.2",
-        "shimmer": "^1.1.0"
       }
     },
     "co": {
@@ -3422,11 +3408,6 @@
         "binary-extensions": "^2.0.0"
       }
     },
-    "is-bluebird": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-bluebird/-/is-bluebird-1.0.2.tgz",
-      "integrity": "sha1-CWQ5Bg9KpBGr7hkUOoTWpVNG1uI="
-    },
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
@@ -4586,9 +4567,9 @@
       }
     },
     "moment": {
-      "version": "2.26.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.26.0.tgz",
-      "integrity": "sha512-oIixUO+OamkUkwjhAVE18rAMfRJNsNe/Stid/gwHSOfHrOtw9EhAY2AHvdKZ/k/MggcYELFCJz/Sn2pL8b8JMw=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-timezone": {
       "version": "0.5.31",
@@ -5850,7 +5831,8 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "semver-diff": {
       "version": "3.1.1",
@@ -5889,33 +5871,31 @@
       }
     },
     "sequelize": {
-      "version": "5.21.10",
-      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-5.21.10.tgz",
-      "integrity": "sha512-qni5lKIa4wBdbi3KQYj20R5TC0/a88qi/1XhGDzDvTaWxhx4gEpLr6aGwvfbvVD7XCilvOgjoBkBB0fLVpwNsw==",
+      "version": "6.3.5",
+      "resolved": "https://registry.npmjs.org/sequelize/-/sequelize-6.3.5.tgz",
+      "integrity": "sha512-MiwiPkYSA8NWttRKAXdU9h0TxP6HAc1fl7qZmMO/VQqQOND83G4nZLXd0kWILtAoT9cxtZgFqeb/MPYgEeXwsw==",
       "requires": {
-        "bluebird": "^3.5.0",
-        "cls-bluebird": "^2.1.0",
         "debug": "^4.1.1",
         "dottie": "^2.0.0",
         "inflection": "1.12.0",
         "lodash": "^4.17.15",
-        "moment": "^2.24.0",
-        "moment-timezone": "^0.5.21",
+        "moment": "^2.26.0",
+        "moment-timezone": "^0.5.31",
         "retry-as-promised": "^3.2.0",
-        "semver": "^6.3.0",
-        "sequelize-pool": "^2.3.0",
+        "semver": "^7.3.2",
+        "sequelize-pool": "^6.0.0",
         "toposort-class": "^1.0.1",
-        "uuid": "^3.3.3",
+        "uuid": "^8.1.0",
         "validator": "^10.11.0",
-        "wkx": "^0.4.8"
+        "wkx": "^0.5.0"
       },
       "dependencies": {
         "debug": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
+          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
           "requires": {
-            "ms": "^2.1.1"
+            "ms": "2.1.2"
           }
         },
         "ms": {
@@ -5923,17 +5903,17 @@
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
           "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
         },
-        "uuid": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+        "semver": {
+          "version": "7.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+          "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
         }
       }
     },
     "sequelize-pool": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-2.3.0.tgz",
-      "integrity": "sha512-Ibz08vnXvkZ8LJTiUOxRcj1Ckdn7qafNZ2t59jYHMX1VIebTAOYefWdRYFt6z6+hy52WGthAHAoLc9hvk3onqA=="
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/sequelize-pool/-/sequelize-pool-6.1.0.tgz",
+      "integrity": "sha512-4YwEw3ZgK/tY/so+GfnSgXkdwIJJ1I32uZJztIEgZeAO6HMgj64OzySbWLgxj+tXhZCJnzRfkY9gINw8Ft8ZMg=="
     },
     "serve-static": {
       "version": "1.14.1",
@@ -6010,11 +5990,6 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true,
       "optional": true
-    },
-    "shimmer": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-      "integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
     },
     "signal-exit": {
       "version": "3.0.3",
@@ -7085,9 +7060,9 @@
       }
     },
     "wkx": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.4.8.tgz",
-      "integrity": "sha512-ikPXMM9IR/gy/LwiOSqWlSL3X/J5uk9EO2hHNRXS41eTLXaUFEVw9fn/593jW/tE5tedNg8YjT5HkCa4FqQZyQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/wkx/-/wkx-0.5.0.tgz",
+      "integrity": "sha512-Xng/d4Ichh8uN4l0FToV/258EjMGU9MGcA0HV2d9B/ZpZB3lqQm7nkOdZdm5GhKtLLhAE7PiVQwN4eN+2YJJUg==",
       "requires": {
         "@types/node": "*"
       }

--- a/api/package.json
+++ b/api/package.json
@@ -22,7 +22,7 @@
 		"pg": "^8.2.1",
 		"pg-hstore": "^2.3.3",
 		"redis": "^3.0.2",
-		"sequelize": "^5.21.10",
+		"sequelize": "^6.3.5",
 		"step-wise": "file:../shared",
 		"uuid": "^8.2.0"
 	},

--- a/api/package.json
+++ b/api/package.json
@@ -5,7 +5,8 @@
 		"test": "cross-env POSTGRES_DB=\"testing\" jest --runInBand tests/.*\\.test\\.js",
 		"test:watch": "cross-env POSTGRES_DB=\"testing\" jest --watch --runInBand tests/.*\\.test\\.js",
 		"db:seed": "node scripts/seedDb.js",
-		"db:clear": "node scripts/clearDb.js"
+		"db:clear": "node scripts/clearDb.js",
+		"db:migrate": "node scripts/migrateDb.js"
 	},
 	"dependencies": {
 		"@hapi/joi": "^17.1.1",
@@ -24,6 +25,7 @@
 		"redis": "^3.0.2",
 		"sequelize": "^6.3.5",
 		"step-wise": "file:../shared",
+		"umzug": "^2.3.0",
 		"uuid": "^8.2.0"
 	},
 	"devDependencies": {

--- a/api/scripts/clearDb.js
+++ b/api/scripts/clearDb.js
@@ -1,12 +1,12 @@
 const { Database } = require('../src/database')
 const { createSequelize } = require('./init')
+const { clearDatabaseSchema } = require('../tests/testutil')
 
 const sequelize = createSequelize()
 
 sequelize.authenticate()
 	.then(() => new Database(sequelize))
 	.then(async () => {
-		await sequelize.drop({ cascade: true })
-		await sequelize.sync({ force: true })
+		await clearDatabaseSchema(sequelize)
 	})
 	.catch(console.error)

--- a/api/scripts/init.js
+++ b/api/scripts/init.js
@@ -4,6 +4,8 @@ const SurfConext = require('../src/server/surfConext/client')
 const session = require('express-session')
 const Redis = require('redis')
 const RedisStore = require('connect-redis')(session)
+const path = require('path')
+const Umzug = require('umzug')
 
 module.exports.createSequelize = () => new Sequelize(
 	process.env.POSTGRES_DB,
@@ -34,4 +36,17 @@ module.exports.createRedisStore = () => new RedisStore({
 		host: process.env.REDIS_HOST,
 		port: process.env.REDIS_PORT,
 	})
+})
+
+module.exports.createUmzug = (sequelize) => new Umzug({
+	migrations: {
+		path: path.join(__dirname, '../migrations'),
+		params: [
+			sequelize.getQueryInterface()
+		]
+	},
+	storage: 'sequelize',
+	storageOptions: {
+		sequelize: sequelize
+	}
 })

--- a/api/scripts/migrateDb.js
+++ b/api/scripts/migrateDb.js
@@ -1,0 +1,59 @@
+const path = require('path')
+const Umzug = require('umzug')
+const { createSequelize } = require('./init')
+
+const sequelize = createSequelize()
+
+const umzug = new Umzug({
+	migrations: {
+		path: path.join(__dirname, '../migrations'),
+		params: [
+			sequelize.getQueryInterface()
+		]
+	},
+	storage: 'sequelize',
+	storageOptions: {
+		sequelize: sequelize
+	}
+})
+
+;(async () => {
+	await printPendingMigrations(umzug)
+	const action = process.argv[2]
+	if (action === 'up') {
+		await migrateUp(umzug)
+	}
+	if (action === 'down') {
+		await migrateDown(umzug)
+	}
+})()
+
+async function printPendingMigrations(umzug) {
+	const pending = await umzug.pending()
+	if (pending && pending.length > 0) {
+		console.log('Pending migration scripts:')
+		pending.forEach((m, i) => {
+			console.log(`${i + 1}: ${m.file}`)
+		})
+	} else {
+		console.log('No pending migrations scripts')
+	}
+}
+
+async function migrateUp(umzug) {
+	try {
+		return await umzug.up()
+	} catch(e) {
+		console.error(e)
+		process.exit(1)
+	}
+}
+
+async function migrateDown(umzug) {
+	try {
+		return await umzug.down()
+	} catch (e) {
+		console.error(e)
+		process.exit(1)
+	}
+}

--- a/api/scripts/migrateDb.js
+++ b/api/scripts/migrateDb.js
@@ -1,21 +1,7 @@
-const path = require('path')
-const Umzug = require('umzug')
-const { createSequelize } = require('./init')
+const { createSequelize, createUmzug } = require('./init')
 
 const sequelize = createSequelize()
-
-const umzug = new Umzug({
-	migrations: {
-		path: path.join(__dirname, '../migrations'),
-		params: [
-			sequelize.getQueryInterface()
-		]
-	},
-	storage: 'sequelize',
-	storageOptions: {
-		sequelize: sequelize
-	}
-})
+const umzug = createUmzug(sequelize)
 
 ;(async () => {
 	await printPendingMigrations(umzug)

--- a/api/src/database/models/ExerciseSample.js
+++ b/api/src/database/models/ExerciseSample.js
@@ -23,7 +23,7 @@ module.exports = (sequelize, DataTypes) => {
 
 	ExerciseSample.associate = models => {
 		ExerciseSample.belongsTo(models.UserSkill)
-		ExerciseSample.hasMany(models.ExerciseEvent, { as: 'events', onDelete: 'CASCADE' })
+		ExerciseSample.hasMany(models.ExerciseEvent, { as: 'events' })
 	}
 
 	return ExerciseSample

--- a/api/src/database/models/UserSkill.js
+++ b/api/src/database/models/UserSkill.js
@@ -35,16 +35,11 @@ module.exports = (sequelize, DataTypes) => {
 			defaultValue: DataTypes.NOW,
 			allowNull: false,
 		},
-	}, {
-		indexes: [{
-			unique: true,
-			fields: ['userId', 'skillId'],
-		}]
 	})
 
 	UserSkill.associate = models => {
 		UserSkill.belongsTo(models.User)
-		UserSkill.hasMany(models.ExerciseSample, { as: 'exercises', onDelete: 'CASCADE' })
+		UserSkill.hasMany(models.ExerciseSample, { as: 'exercises' })
 	}
 
 	return UserSkill

--- a/api/tests/client.js
+++ b/api/tests/client.js
@@ -3,6 +3,8 @@ const { createServer } = require('../src/server')
 const { createSequelize, createUmzug } = require('../scripts/init')
 const SurfConextMock = require('../src/server/surfConext/devmock')
 const { Database } = require('../src/database')
+const { clearDatabaseSchema } = require('./testutil')
+
 const noop = () => {}
 
 const defaultConfig = Object.freeze({
@@ -82,8 +84,7 @@ class Client {
 }
 
 const createClient = async (seedingProcedure = noop) => {
-	await sequelize.query('DROP SCHEMA IF EXISTS public CASCADE;')
-	await sequelize.query('CREATE SCHEMA public;')
+	clearDatabaseSchema(sequelize)
 	const umzug = createUmzug(sequelize)
 	await umzug.up()
 	await seedingProcedure(database)

--- a/api/tests/client.js
+++ b/api/tests/client.js
@@ -84,7 +84,7 @@ class Client {
 }
 
 const createClient = async (seedingProcedure = noop) => {
-	clearDatabaseSchema(sequelize)
+	await clearDatabaseSchema(sequelize)
 	const umzug = createUmzug(sequelize)
 	await umzug.up()
 	await seedingProcedure(database)

--- a/api/tests/client.js
+++ b/api/tests/client.js
@@ -1,6 +1,6 @@
 const request = require('supertest')
 const { createServer } = require('../src/server')
-const { createSequelize } = require('../scripts/init')
+const { createSequelize, createUmzug } = require('../scripts/init')
 const SurfConextMock = require('../src/server/surfConext/devmock')
 const { Database } = require('../src/database')
 const noop = () => {}
@@ -84,7 +84,8 @@ class Client {
 const createClient = async (seedingProcedure = noop) => {
 	await sequelize.query('DROP SCHEMA IF EXISTS public CASCADE;')
 	await sequelize.query('CREATE SCHEMA public;')
-	await sequelize.sync({ force: true })
+	const umzug = createUmzug(sequelize)
+	await umzug.up()
 	await seedingProcedure(database)
 	return new Client()
 }

--- a/api/tests/testutil.js
+++ b/api/tests/testutil.js
@@ -1,0 +1,12 @@
+const clearDatabaseSchema = async (sequelize) => {
+	const schema = await(async () => {
+		const [result] = await sequelize.query('SELECT current_schema();')
+		return result[0].current_schema
+	})()
+	await sequelize.query(`DROP SCHEMA IF EXISTS ${schema} CASCADE;`)
+	await sequelize.query(`CREATE SCHEMA ${schema};`)
+}
+
+module.exports = {
+	clearDatabaseSchema
+}

--- a/ops/bin/release
+++ b/ops/bin/release
@@ -42,8 +42,8 @@ docker-compose -f ops/docker-compose.yml -p app pull
 
 echo -e '\033[46m [STEP 3/4] \033[0m Restart application, run migrations'
 systemctl stop app
-# TODO replace with migration:
-docker-compose -f ops/docker-compose.yml -p app run --rm api npm run db:clear
+docker-compose -f ops/docker-compose.yml -p app run --rm api \
+	/bin/sh -c "npm run db:clear && npm run db:migrate -- up"
 systemctl start app
 
 echo -e '\033[46m [STEP 4/4] \033[0m Cleanup'


### PR DESCRIPTION
The migrations are now ready to go.

- The biggest change is how you work with sequelize models now: in contrast to how it used to be before, the models don’t have any functionality on their own anymore, except for expressing an existing database structure (i.e. tables and their relations to each other).
- The models themselves are not involved in the process of actually creating tables or setting indexes. That must all happen via migrations now. You find those in the `/api/migrations` folder. They are processed sequentially, hence the numeric prefix of the filenames.
- All migration files are supposed to be immutable – once they are run (in prod), you shouldn’t touch them anymore. All changes must be applied via additional migration steps.
- We use [Umzug](https://github.com/sequelize/umzug) for the migrations (it’s from the sequelize people). v3 is still in beta, so it’s v2.3 for now. No idea what their timeline is.
- I also upgraded to sequelize 6. We shouldn’t be affected by breaking changes, though (see [Changelog](https://sequelize.org/master/manual/upgrade-to-v6.html)) – luckily we already abandoned `sequelize.import` early on ;)
- The release process is still the same, we clear the DB on all releases for the time being.
- In addition to `npm run db:clear` and `npm run db:seed`, there is `npm run db:migrate` now. It only displays pending migrations by default. If you want to execute something you need to pass a subcommand: (note the extra space after `--`)
  - `npm run db:migrate -- up` runs all pending migrations
  - `npm run db:migrate -- down` reverts the last migration (one at a time)