### PR TITLE
All user properties (SurfConext)

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,15 @@
 - **Issue HTTPS certificates**: `ssh -t step-wise.com issue-certificates`
 
 See the [`ops/`](ops/) folder for background information.
+
+## Development commands
+
+See the `script` section in the respective `package.json` files.
+
+For interacting with the database:
+
+- `npm run db:clear` Erase the entire database schema (content and structure) and sets up a fresh one
+- `npm run db:seed` Fills sample data into the DB
+- `npm run db:migrate` Checks whether there are pending migrations
+	- `npm run db:migrate -- up` Applies all pending migrations
+	- `npm run db:migrate -- down` Reverts the last migration

--- a/api/migrations/006_alter-table-add-userprops.js
+++ b/api/migrations/006_alter-table-add-userprops.js
@@ -1,0 +1,55 @@
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+	up: async (queryInterface) => {
+		await queryInterface.addColumn('users', 'role', {
+			type: DataTypes.ENUM([
+				'student',
+				'teacher',
+				'admin',
+			]),
+			defaultValue: 'student',
+			allowNull: false,
+		})
+		await queryInterface.addColumn('users', 'givenName', {
+			type: DataTypes.TEXT,
+			allowNull: true,
+		})
+		await queryInterface.addColumn('users', 'familyName', {
+			type: DataTypes.TEXT,
+			allowNull: true,
+		})
+		await queryInterface.changeColumn('users', 'name', {
+			type: DataTypes.TEXT,
+			allowNull: true,
+		})
+		await queryInterface.changeColumn('users', 'email', {
+			type: DataTypes.TEXT,
+			allowNull: true,
+		})
+		await queryInterface.addColumn('surfConextProfiles', 'schacPersonalUniqueCode', {
+			type: DataTypes.ARRAY(DataTypes.TEXT),
+		})
+		await queryInterface.addColumn('surfConextProfiles', 'locale', {
+			type: DataTypes.TEXT,
+		})
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.removeColumn('users', 'role')
+		await queryInterface.removeColumn('users', 'givenName')
+		await queryInterface.removeColumn('users', 'familyName')
+		await queryInterface.changeColumn('users', 'name', {
+			type: DataTypes.TEXT,
+			allowNull: false,
+		})
+		await queryInterface.changeColumn('users', 'email', {
+			type: DataTypes.TEXT,
+			allowNull: false,
+		})
+		await queryInterface.removeColumn('surfConextProfiles', 'schacPersonalUniqueCode')
+		await queryInterface.removeColumn('surfConextProfiles', 'locale')
+		await queryInterface.sequelize.query('drop type enum_users_role;')
+	},
+
+}

--- a/api/scripts/seedDb.js
+++ b/api/scripts/seedDb.js
@@ -16,7 +16,9 @@ async function seedTestData(db) {
 	// Create a user.
 	const user = await db.User.create({
 		id: '01234567-89ab-cdef-0123-456789abcdef',
-		name: 'Step',
+		name: 'Step Wise',
+		givenName: 'Step',
+		familyName: 'Wise',
 		email: 'step@wise.com',
 		createdAt: date.setSeconds(date.getSeconds() + 1)
 	})

--- a/api/src/database/models/SurfConextProfile.js
+++ b/api/src/database/models/SurfConextProfile.js
@@ -10,7 +10,13 @@ module.exports = (sequelize) => {
 		},
 		schacHomeOrganization: {
 			type: DataTypes.TEXT,
-		}
+		},
+		schacPersonalUniqueCode: {
+			type: DataTypes.ARRAY(DataTypes.TEXT),
+		},
+		locale: {
+			type: DataTypes.TEXT,
+		},
 	})
 
 	SurfConextProfile.associate = models => {

--- a/api/src/database/models/User.js
+++ b/api/src/database/models/User.js
@@ -9,13 +9,32 @@ module.exports = (sequelize) => {
 			primaryKey: true,
 		},
 		name: {
+			// This is the full name, potentially including
+			// the academic title
 			type: DataTypes.TEXT,
-			allowNull: false,
+			allowNull: true,
+		},
+		givenName: {
+			type: DataTypes.TEXT,
+			allowNull: true,
+		},
+		familyName: {
+			type: DataTypes.TEXT,
+			allowNull: true,
 		},
 		email: {
 			type: DataTypes.TEXT,
+			allowNull: true,
+		},
+		role: {
+			type: DataTypes.ENUM([
+				'student',
+				'teacher',
+				'admin',
+			]),
+			defaultValue: 'student',
 			allowNull: false,
-		}
+		},
 	})
 
   User.associate = models => {

--- a/api/src/database/models/User.js
+++ b/api/src/database/models/User.js
@@ -12,19 +12,15 @@ module.exports = (sequelize) => {
 			// This is the full name, potentially including
 			// the academic title
 			type: DataTypes.TEXT,
-			allowNull: true,
 		},
 		givenName: {
 			type: DataTypes.TEXT,
-			allowNull: true,
 		},
 		familyName: {
 			type: DataTypes.TEXT,
-			allowNull: true,
 		},
 		email: {
 			type: DataTypes.TEXT,
-			allowNull: true,
 		},
 		role: {
 			type: DataTypes.ENUM([

--- a/api/src/graphql/schemas/User.js
+++ b/api/src/graphql/schemas/User.js
@@ -7,8 +7,11 @@ const schema = gql`
 
 	type User {
 		id: ID!
-		name: String!
-		email: EmailAddress!
+		name: String
+		givenName: String
+		familyName: String
+		email: EmailAddress
+		role: String!
 		skills(ids: [String]): [SkillWithoutExercises]!
 	}
 `

--- a/api/src/server/surfConext/authStrategy.js
+++ b/api/src/server/surfConext/authStrategy.js
@@ -28,17 +28,28 @@ class AuthStrategy extends AuthStrategyTemplate {
 			const [user] = await this._db.User.upsert({
 				// Update if user exists, otherwise a new one gets created
 				id: surfProfile ? surfProfile.user.id : undefined,
-				name: surfRawData.name,
-				email: surfRawData.email,
+				name: surfRawData.name || undefined,
+				givenName: surfRawData.given_name || undefined,
+				familyName: surfRawData.family_name || undefined,
+				email: surfRawData.email || undefined,
+				role: getRole(surfRawData),
 			}, { returning: true, transaction: t })
 			await this._db.SurfConextProfile.upsert({
 				id: surfRawData.sub,
 				userId: user.id,
 				schacHomeOrganization: surfRawData.schac_home_organization,
+				schacPersonalUniqueCode: surfRawData.schac_personal_unique_code,
+				locale: surfRawData.locale,
 			}, { transaction: t })
 			return user
 		})
 	}
+}
+
+function getRole(surfRawData) {
+	const affiliation = surfRawData.eduperson_affiliation
+	if (affiliation.includes('teacher')) return 'teacher'
+	return undefined // use default
 }
 
 module.exports = {

--- a/api/surfConextMockData.json
+++ b/api/surfConextMockData.json
@@ -8,9 +8,13 @@
 		"nickname": "Step Wise",
 		"email": "step@wise.com",
 		"schac_home_organization": "eduid.nl",
-		"eduperson_affiliation": [],
-		"locale": "",
-		"schac_personal_unique_code": ""
+		"eduperson_affiliation": [
+			"student"
+		],
+		"locale": "nl, en-gb;q=0.8, en;q=0.7",
+		"schac_personal_unique_code": [
+			"urn:schac:personalUniqueCode:nl:local:eduid.nl:employeeid:x12-3456"
+		]
 	},
 	{
 		"sub": "1111111111111111111111111111111111111111",
@@ -22,7 +26,7 @@
 		"email": "john@example.org",
 		"schac_home_organization": "eduid.nl",
 		"eduperson_affiliation": [],
-		"locale": "",
-		"schac_personal_unique_code": ""
+		"locale": null,
+		"schac_personal_unique_code": null
 	}
 ]

--- a/api/surfConextMockData.json
+++ b/api/surfConextMockData.json
@@ -2,10 +2,8 @@
 	{
 		"sub": "0000000000000000000000000000000000000000",
 		"name": "Step Wise",
-		"preferred_username": "Step Wise",
 		"given_name": "Step",
 		"family_name": "Wise",
-		"nickname": "Step Wise",
 		"email": "step@wise.com",
 		"schac_home_organization": "eduid.nl",
 		"eduperson_affiliation": [
@@ -18,14 +16,23 @@
 	},
 	{
 		"sub": "1111111111111111111111111111111111111111",
-		"name": "John Doe",
-		"preferred_username": "John Doe",
-		"given_name": "John",
-		"family_name": "Doe",
-		"nickname": "John Doe",
-		"email": "john@example.org",
+		"name": null,
+		"given_name": null,
+		"family_name": null,
+		"email": null,
 		"schac_home_organization": "eduid.nl",
 		"eduperson_affiliation": [],
+		"locale": null,
+		"schac_personal_unique_code": null
+	},
+	{
+		"sub": "2222222222222222222222222222222222222222",
+		"name": "Prof. Richard Feynman",
+		"given_name": "Richard",
+		"family_name": "Feynman",
+		"email": "r.feynman@mit.edu",
+		"schac_home_organization": "mit.edu",
+		"eduperson_affiliation": ["teacher"],
 		"locale": null,
 		"schac_personal_unique_code": null
 	}

--- a/api/tests/server/authentication.test.js
+++ b/api/tests/server/authentication.test.js
@@ -70,7 +70,9 @@ describe('Authentication', () => {
 			const user = await db.User.create({
 				id: SPECIAL_USER_ID,
 				name: 'Old Name',
-				email: 'old@email.com'
+				email: 'old@email.com',
+				givenName: 'Old given name',
+				familyName: 'Old family name',
 			})
 			await user.createSurfConextProfile({
 				id: SPECIAL_USER_SURFSUB,
@@ -82,11 +84,16 @@ describe('Authentication', () => {
 		).resolves.toEqual(defaultConfig.homepageUrl)
 
 		await expect(
-			client.graphql({ query: `{me {id name email}}` }).then(({ data }) => data.me)
+			client.graphql({
+				query: `{me {id name givenName familyName email role}}`
+			}).then(({ data }) => data.me)
 		).resolves.toEqual({
 			id: SPECIAL_USER_ID,
 			name: 'Step Wise',
+			givenName: 'Step',
+			familyName: 'Wise',
 			email: 'step@wise.com',
+			role: 'student',
 		})
 	})
 
@@ -94,14 +101,39 @@ describe('Authentication', () => {
 		const client = await createClient()
 
 		await expect(
+			client.login('2222222222222222222222222222222222222222')
+		).resolves.toEqual(defaultConfig.homepageUrl)
+
+		await expect(
+			client.graphql({
+				query: `{me {name givenName familyName email role}}`
+			}).then(({ data }) => data.me)
+		).resolves.toEqual({
+			name: 'Prof. Richard Feynman',
+			givenName: 'Richard',
+			familyName: 'Feynman',
+			email: 'r.feynman@mit.edu',
+			role: 'teacher',
+		})
+	})
+
+	it('automatically creates account with minimal user props', async () => {
+		const client = await createClient()
+
+		await expect(
 			client.login('1111111111111111111111111111111111111111')
 		).resolves.toEqual(defaultConfig.homepageUrl)
 
 		await expect(
-			client.graphql({ query: `{me {name email}}` }).then(({ data }) => data.me)
+			client.graphql({
+				query: `{me {name givenName familyName email role}}`
+			}).then(({ data }) => data.me)
 		).resolves.toEqual({
-			name: 'John Doe',
-			email: 'john@example.org',
+			name: null,
+			givenName: null,
+			familyName: null,
+			email: null,
+			role: 'student',
 		})
 	})
 

--- a/api/tests/testutil.js
+++ b/api/tests/testutil.js
@@ -1,8 +1,8 @@
 // You can only run this when you have permissions to
 // change the schema. In a shared production DB you might
 // need to drop the database manually instead.
-const clearDatabaseSchema = async (sequelizeTemplateDb) => {
-	await sequelizeTemplateDb.query(`
+const clearDatabaseSchema = async (sequelize) => {
+	await sequelize.query(`
 		drop schema if exists public cascade;
 		create schema public;
 	`)

--- a/api/tests/testutil.js
+++ b/api/tests/testutil.js
@@ -1,12 +1,10 @@
-const clearDatabaseSchema = async (sequelize) => {
-	await sequelize.query(`
-		DO $$ DECLARE
-			r RECORD;
-		BEGIN
-				FOR r IN (SELECT tablename FROM pg_tables WHERE schemaname = current_schema()) LOOP
-						EXECUTE 'DROP TABLE IF EXISTS ' || quote_ident(r.tablename) || ' CASCADE';
-				END LOOP;
-		END $$;
+// You can only run this when you have permissions to
+// change the schema. In a shared production DB you might
+// need to drop the database manually instead.
+const clearDatabaseSchema = async (sequelizeTemplateDb) => {
+	await sequelizeTemplateDb.query(`
+		drop schema if exists public cascade;
+		create schema public;
 	`)
 }
 


### PR DESCRIPTION
All requested properties are now getting synced from SurfConext (SF) to our DB. A few things to note:

- Turns out, all names and the email address can be `null` in SF, so I had to make these fields optional. (It doesn’t say so in their docs, but I tried it out. One of the local SF test accounts also has minimal props now, to reflect that case.)
- As discussed, everyone is `student` now by default. The `teacher` prop gets synced if present, `admin` must always be set manually and directly in the DB.
- As we don’t clear the DB in production anymore, the clearing procedure is now simplified and actually more correct. It wouldn’t work in prod, however, since DigitalOcean doesn’t give us enough permission to tinker with the schemas. Clearing the prod DB now would mean destroying it via DigitalOcean and creating a completely new one.
