### PR TITLE
Refactor apollo context (how current user is retrieved)

### DIFF
--- a/api/src/graphql/resolvers/Exercise.js
+++ b/api/src/graphql/resolvers/Exercise.js
@@ -21,8 +21,8 @@ const resolvers = {
 	},
 
 	Mutation: {
-		startExercise: async (_source, { skillId }, { db, getUserIdOrThrow }) => {
-			const userId = getUserIdOrThrow()
+		startExercise: async (_source, { skillId }, { db, getCurrentUserId }) => {
+			const userId = getCurrentUserId()
 			const { skill } = await getActiveExerciseData(userId, skillId, db, false)
 
 			// Select a new exercise, store it and return the result.
@@ -31,8 +31,8 @@ const resolvers = {
 			return await skill.createExercise({ exerciseId: newExercise.exerciseId, state: setFOtoIO(newExercise.state), active: true })
 		},
 
-		submitExerciseAction: async (_source, { skillId, action }, { db, getUserIdOrThrow }) => {
-			const userId = getUserIdOrThrow()
+		submitExerciseAction: async (_source, { skillId, action }, { db, getCurrentUserId }) => {
+			const userId = getCurrentUserId()
 			const { exercise } = await getActiveExerciseData(userId, skillId, db, true)
 
 			// Set up an updateSkills handler that only collects calls.
@@ -57,7 +57,7 @@ const resolvers = {
 
 				// Store the submission and on a correct one update the active field of the exercise to solved.
 				const newEvent = await exercise.createEvent({ action, progress }, { transaction })
-				exercise.events.push(newEvent) // In Sequelize we have to manually add the new action to the current object. 
+				exercise.events.push(newEvent) // In Sequelize we have to manually add the new action to the current object.
 				if (progress.done)
 					await exercise.update({ active: false }, { transaction })
 			})

--- a/api/src/graphql/resolvers/Skill.js
+++ b/api/src/graphql/resolvers/Skill.js
@@ -14,10 +14,10 @@ const resolvers = {
 	},
 
 	Query: {
-		skill: async (_source, { skillId, userId }, { db, getUserIdOrThrow, ensureAdmin }) => {
+		skill: async (_source, { skillId, userId }, { db, getCurrentUserId, ensureAdmin }) => {
 			// If no ID is given, the request is for the current user.
 			if (!userId)
-				return await getUserSkill(getUserIdOrThrow(), skillId, db)
+				return await getUserSkill(getCurrentUserId(), skillId, db)
 
 			// If an ID is given, it's a request for someone else. Only admins are allowed to do so for now.
 			if (userId) {
@@ -25,8 +25,8 @@ const resolvers = {
 				return await getUserSkill(userId, skillId, db)
 			}
 		},
-		skills: async (_source, { skillIds }, { db, getUserIdOrThrow }) => {
-			return await getUserSkills(getUserIdOrThrow(), skillIds, db)
+		skills: async (_source, { skillIds }, { db, getCurrentUserId }) => {
+			return await getUserSkills(getCurrentUserId(), skillIds, db)
 		},
 	},
 }

--- a/api/src/graphql/resolvers/User.js
+++ b/api/src/graphql/resolvers/User.js
@@ -22,11 +22,8 @@ const resolvers = {
 	},
 
 	Mutation: {
-		acceptLatestPrivacyPolicy: async (_source, _args, { getUser }) => {
-			const user = await getUser()
-			if (!user) {
-				throw new AuthenticationError('Not logged in')
-			}
+		acceptLatestPrivacyPolicy: async (_source, _args, { getCurrentUser }) => {
+			const user = await getCurrentUser()
 			// Only run update if we are behind
 			if (!user.privacyPolicyAcceptedVersion || user.privacyPolicyAcceptedVersion < CURRENT_PRIVACY_POLICY_VERSION) {
 				await user.update({
@@ -41,11 +38,8 @@ const resolvers = {
 			}
 		},
 
-		shutdownAccount: async (_source, { confirmEmail }, { getUser }) => {
-			const user = await getUser()
-			if (!user) {
-				throw new AuthenticationError('Not logged in')
-			}
+		shutdownAccount: async (_source, { confirmEmail }, { getCurrentUser }) => {
+			const user = await getCurrentUser()
 			if (user.email !== confirmEmail) {
 				throw new Error('Email (for confirmation) does not match')
 			}
@@ -57,8 +51,12 @@ const resolvers = {
 	},
 
 	Query: {
-		me: async (_source, _args, { getUser }) => {
-			return await getUser()
+		me: async (_source, _args, { getCurrentUser }) => {
+			try {
+				return await getCurrentUser()
+			} catch (AuthenticationError) {
+				return null
+			}
 		},
 
 		user: async (_source, { userId }, { db, ensureAdmin }) => {

--- a/api/src/server/index.js
+++ b/api/src/server/index.js
@@ -63,19 +63,23 @@ const createServer = ({
 			 * Returns the id of the currently logged in user, or throws an error otherwise.
 			 * Beware: this doesn’t guarantee you that the user still exists in the DB!
 			 */
-			getUserIdOrThrow: () => {
-				if (req.session.principal && req.session.principal.id)
-					return req.session.principal.id
-				throw new AuthenticationError('No user is logged in.')
+			getCurrentUserId: () => {
+				if (!req.session.principal || !req.session.principal.id)
+					throw new AuthenticationError('No user is logged in.')
+				return req.session.principal.id
 			},
 
 			/**
-			 * Returns the currently logged in user object, or throws an exception otherwise.
+			 * Returns the currently logged in user object, or throws an error otherwise.
 			 */
 			getCurrentUser: async () => {
-				if (req.session.principal && req.session.principal.id)
-					return await database.User.findByPk(req.session.principal.id)
-				throw new AuthenticationError('No user is logged in.')
+				if (!req.session.principal || !req.session.principal.id)
+					throw new AuthenticationError('No user is logged in.')
+				const user = await database.User.findByPk(req.session.principal.id)
+				if (!user) {
+					throw new AuthenticationError('No such user in the system.')
+				}
+				return user
 			},
 
 			/**

--- a/api/src/server/index.js
+++ b/api/src/server/index.js
@@ -70,12 +70,12 @@ const createServer = ({
 			},
 
 			/**
-			 * Returns the currently logged in user object, or `null` otherwise.
+			 * Returns the currently logged in user object, or throws an exception otherwise.
 			 */
-			getUser: async () => {
-				if (!req.session.principal)
-					return null
-				return await database.User.findByPk(req.session.principal.id)
+			getCurrentUser: async () => {
+				if (req.session.principal && req.session.principal.id)
+					return await database.User.findByPk(req.session.principal.id)
+				throw new AuthenticationError('No user is logged in.')
 			},
 
 			/**

--- a/api/src/server/index.js
+++ b/api/src/server/index.js
@@ -60,12 +60,6 @@ const createServer = ({
 			db: database,
 
 			/**
-			 * Returns the id of the currently logged in user, or `null` otherwise.
-			 * Beware: this doesn’t guarantee you that the user still exists in the DB!
-			 */
-			getUserId: () => req.session.principal ? req.session.principal.id : null,
-
-			/**
 			 * Returns the id of the currently logged in user, or throws an error otherwise.
 			 * Beware: this doesn’t guarantee you that the user still exists in the DB!
 			 */


### PR DESCRIPTION
- Rename `getUserIdOrThrow` to `getCurrentUserId` and make it throw by default
- Remove unused `getUserId`
- Rename `getUser` to `getCurrentUser` and make it throw by default. Adjust the consumers accordingly.

My IDE automatically removes trailing whitespace and adds newlines to the end of the file, so that also slipped in.