### PR TITLE
Fix unique and non null constraint on user email column

### DIFF
--- a/api/migrations/009_alter-table-users-email-non-null.js
+++ b/api/migrations/009_alter-table-users-email-non-null.js
@@ -1,0 +1,32 @@
+const { DataTypes } = require('sequelize')
+
+module.exports = {
+	up: async (queryInterface) => {
+		// We better let Sequelize take care of introducing a unique constraint with an
+		// index via the `unique: true` property, instead of creating the index manually.
+		// So we remove the index created in migration 008 and re-introduce it below via
+		// the property.
+		await queryInterface.removeIndex('users', 'users_email')
+
+		// The NON NULL constraint was accidentally removed in migration 006,
+		// so we bring it back here.
+		await queryInterface.changeColumn('users', 'email', {
+			type: DataTypes.TEXT,
+			allowNull: false,
+			unique: true,
+		})
+	},
+
+	down: async (queryInterface) => {
+		await queryInterface.changeColumn('users', 'email', {
+			type: DataTypes.TEXT,
+			allowNull: true,
+			unique: false,
+		})
+
+		await queryInterface.addIndex('users', {
+			fields: ['email'],
+			unique: true,
+		})
+	},
+}

--- a/api/src/database/models/User.js
+++ b/api/src/database/models/User.js
@@ -21,6 +21,8 @@ module.exports = (sequelize) => {
 		},
 		email: {
 			type: DataTypes.TEXT,
+			unique: true,
+			allowNull: false,
 		},
 		role: {
 			type: DataTypes.ENUM([

--- a/api/surfConextMockData.json
+++ b/api/surfConextMockData.json
@@ -19,7 +19,7 @@
 		"name": null,
 		"given_name": null,
 		"family_name": null,
-		"email": null,
+		"email": "foo@example.org",
 		"schac_home_organization": null,
 		"eduperson_affiliation": null,
 		"locale": null,

--- a/api/tests/server/api/user.test.js
+++ b/api/tests/server/api/user.test.js
@@ -10,7 +10,7 @@ const seed = async db => {
 	const student = await db.User.create({
 		id: STUDENT_ID,
 		name: 'Student',
-		email: 'student@wise.com',
+		email: 'foo@example.org',
 	})
 	await student.createSurfConextProfile({
 		id: STUDENT_SURFSUB,
@@ -139,7 +139,7 @@ describe('shutdown account', () => {
 		await client.login(STUDENT_SURFSUB)
 
 		const { data: shutdownData, errors: shutdownErrors } = await client.graphql(
-			{ query: `mutation {shutdownAccount(confirmEmail: "student@wise.com")}` }
+			{ query: `mutation {shutdownAccount(confirmEmail: "foo@example.org")}` }
 		)
 		expect(shutdownErrors).toBeUndefined()
 		expect(shutdownData).toMatchObject({ shutdownAccount: STUDENT_ID })
@@ -155,7 +155,7 @@ describe('shutdown account', () => {
 		const client = await createClient(seed)
 
 		const { data, errors } = await client.graphql(
-			{ query: `mutation {shutdownAccount(confirmEmail: "student@wise.com")}` }
+			{ query: `mutation {shutdownAccount(confirmEmail: "foo@example.org")}` }
 		)
 		expect(errors).not.toBeUndefined()
 		expect(data).toBeNull()

--- a/api/tests/server/authentication.test.js
+++ b/api/tests/server/authentication.test.js
@@ -132,7 +132,7 @@ describe('Authentication', () => {
 			name: null,
 			givenName: null,
 			familyName: null,
-			email: null,
+			email: 'foo@example.org',
 			role: 'student',
 		})
 	})


### PR DESCRIPTION
I realized that the migration from yesterday was not optimal, because apparently Sequelize generates different names for indexes when creating with `addIndex` vs. with `{unique: true}` on the model itself. The latter introduces an index implicitly, but the name is different (`users_email` vs `users_email_key`).

In order for the Model to work properly, we need to redo the index. Also, I noticed that for some reason we removed the `NON NULL` constraint on the `email` column in migration `006`. Now that we have the index, we shouldn’t allow `NULL` values anymore, though.