### PR TITLE
Check authentication on socket connect

### DIFF
--- a/api/src/server/apollo.js
+++ b/api/src/server/apollo.js
@@ -64,5 +64,5 @@ function getPrincipalOrThrow(request) {
 }
 
 module.exports = {
-	createApolloContext
+	createApolloContext, getPrincipalOrThrow
 }


### PR DESCRIPTION
This PR introduces an initial authentication check, when the user establishes a connection to the websocket. Should the user not be authenticated, the socket refuses the connection altogether.

<img width="814" alt="Screenshot 2022-03-23 at 09 45 12" src="https://user-images.githubusercontent.com/3618384/159658985-1b6d95ef-7d73-421a-b436-7901f621306f.png">
