### PR TITLE
Automatically reconnect to websocket

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -12,7 +12,9 @@ import { graphqlAddress, graphqlWebsocketAddress } from './ui/settings'
 const wsLink = new WebSocketLink(
 	new SubscriptionClient(
 		graphqlWebsocketAddress,
-		{},
+		{
+			reconnect: true,
+		},
 	)
 )
 


### PR DESCRIPTION
With this option, the client will automatically re-connect to the websocket in case the connection was interrupted (e.g. due to a network outage or server restart).