### PR TITLE
Fix resolving of JSON data

### DIFF
--- a/api/src/graphql/resolvers/index.js
+++ b/api/src/graphql/resolvers/index.js
@@ -1,4 +1,4 @@
-const { EmailAddressResolver, DateTimeResolver, JSONObjectResolver } = require('graphql-scalars')
+const { EmailAddressResolver, DateTimeResolver, JSONResolver } = require('graphql-scalars')
 
 const resolverKeys = [
 	'User',
@@ -11,7 +11,7 @@ const resolverKeys = [
 const scalarResolvers = {
 	EmailAddress: EmailAddressResolver,
 	DateTime: DateTimeResolver,
-	JSON: JSONObjectResolver,
+	JSON: JSONResolver,
 }
 
 // Put all resolvers into one big array and export it.


### PR DESCRIPTION
With the upgrade to Apollo Server v3, I had to also upgrade [`graphql-scalars` to the latest version](https://github.com/HildoBijl/stepwise/blob/5a3af3434ef1fd168342a2f50307df1f93e3fe52/api/package.json#L26).

On master (and in production) there is currently an error when submitting queries that contain a `JSON` type.

<img width="940" alt="Screenshot 2022-03-23 at 15 49 10" src="https://user-images.githubusercontent.com/3618384/159727568-f625299e-7ac6-4ba3-8ae8-e86ab29d4ff8.png">

So it might be, that there is a breaking change? I’m not sure why we used `JSONObject` over `JSON` to begin with, i.e whether there was a specific reason behind that?

Could you double-check this @HildoBijl , since you introduced the type originally? For me, it appears to work, at least from a “superficial” level.